### PR TITLE
Ensure app module is discovered by uvicorn

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,4 +5,5 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8002
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]
+# Ensure the application directory is on the Python path when running the server
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002", "--app-dir", "/app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./backend:/app
     networks:
       - infrastructure_net_backendservices
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8002 --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8002 --reload --app-dir /app
 
   s_dogus_erp_frontend:
     build: ./frontend


### PR DESCRIPTION
## Summary
- add `--app-dir /app` to uvicorn command so the backend container always finds the `app` package
- document path handling in backend Dockerfile

## Testing
- `cd backend && PYTHONPATH=. pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bb2953d88c832c866f744faad4ebd0